### PR TITLE
chore: remove unnecessary run condition

### DIFF
--- a/.github/workflows/build_and_push.yml
+++ b/.github/workflows/build_and_push.yml
@@ -3,8 +3,6 @@ name: build_and_push
 on:
   release:
     types: [published]
-  push: 
-    branches: ["main"]
 
 jobs:
   build_and_push:


### PR DESCRIPTION
# 설명
- removed push condition. 

# ISSUE
- kept "push to the main branch" as a run condition in build_and_push.yml, which was only added for testing purposes.

# 테스트
N/A