### PR TITLE
fix: centre CTA button on mobile in our team page

### DIFF
--- a/src/app/our-team/page.styled.ts
+++ b/src/app/our-team/page.styled.ts
@@ -170,7 +170,9 @@ export const CTAButton = styled.a`
   }
 
   @media (max-width: 768px) {
-    width: 100%;
+    width: auto;
+    height: 52px;
+    align-self: center;
   }
 `;
 


### PR DESCRIPTION
# Description
- Remove full width and center align CTA button on mobile
# Issue
- n/a
# Testing
- n/a
